### PR TITLE
Bundle mawk.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -139,6 +139,7 @@ parts:
     files:
       src/php/config/*: config/php/
       src/php/scripts/*: bin/
+    stage-packages: [mawk]
 
   # Copy over our Nextcloud configuration files
   nextcloud-customizations:

--- a/src/php/scripts/start-php-fpm
+++ b/src/php/scripts/start-php-fpm
@@ -27,7 +27,7 @@ fi
 
 # Tends to be between 30-50MB
 average_php_memory_requirement=50
-total_memory=$(awk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
+total_memory=$(mawk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
 export PHP_FPM_MAX_CHILDREN=$(($total_memory/$average_php_memory_requirement))
 
 php-fpm -R -F --fpm-config ${SNAP}/config/php/php-fpm.conf -c ${SNAP}/config/php


### PR DESCRIPTION
This PR fixes #11 by bundling mawk into the snap rather than relying on the one in core. Otherwise LP: #1580018 allows the host system to mess with the awk found by snaps. When that bug is fixed this PR can be reverted.